### PR TITLE
ardupilot: added MAV_CMD_FIXED_MAG_CAL_YAW

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -111,6 +111,16 @@
         <param index="6">Empty.</param>
         <param index="7">Empty.</param>
       </entry>
+      <entry value="42006" name="MAV_CMD_FIXED_MAG_CAL_YAW">
+        <description>Magnetometer calibration based on provided known yaw. This allows for fast calibration using WMM field tables in the vehicle, given only the known yaw of the vehicle. If Latitude and longitude are both zero then use the current vehicle location.</description>
+        <param index="1">YawDegrees.</param>
+        <param index="2">CompassMask, 0 for all.</param>
+        <param index="3">Latitude degrees.</param>
+        <param index="4">Longitude degrees.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
       <entry value="42424" name="MAV_CMD_DO_START_MAG_CAL">
         <description>Initiate a magnetometer calibration.</description>
         <param index="1">uint8_t bitmask of magnetometers (0 means all).</param>


### PR DESCRIPTION
this allows for fast compass calibration using just the known yaw of
the vehicle. This is ideal for large vehicles, if the user is able to
place the vehicle in a location without significant field distortions